### PR TITLE
Add keyboard shortcut handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
+# ESP32-S3 Digital Typewriter Firmware
 
+This repository contains a minimal Arduino-based firmware targeting the Waveshare **ESP32-S3-LCD-1.47B** board. The goal is to provide a simple digital typewriter with the following features:
+
+- Text editing on the built-in 1.47" TFT using a USB keyboard connected to the board
+- Saving and loading notes from SPIFFS
+- Sending the entire note as USB HID keyboard keystrokes to a connected phone
+- All operations controlled via keyboard shortcuts (no touch or buttons)
+
+## Building
+
+The firmware uses the [ESP32 Arduino core](https://github.com/espressif/arduino-esp32). Import the project into the Arduino IDE or [PlatformIO](https://platformio.org/). Select **ESP32S3 Dev Module** as the board and make sure USB mode is set to **OTG**. The TFT must be configured in `TFT_eSPI/User_Setup.h` for an ST7789 display of size 172×320.
+
+Required libraries:
+
+- `TFT_eSPI` for display control (configured for ST7789 172x320)
+- `USB` and `USBHost` from the ESP32 Arduino core
+
+Upload the sketch in `src/main.cpp` to the device. If you prefer using `arduino-cli`, install it and run:
+
+```bash
+arduino-cli compile --fqbn esp32:esp32:esp32s3 src
+```
+
+## Keyboard Shortcuts
+
+- **F1** – Save note to `/note.txt`
+- **F2** – Load note from `/note.txt`
+- **F3** – Send note to the phone as keystrokes
+
+These shortcuts can be adapted inside `src/main.cpp`. The firmware relies solely on the USB keyboard for input—there are no physical buttons used.
+
+This project is intended as a starting point. The code is heavily commented for ease of extension. Refer to the board's [wiki](https://www.waveshare.com/wiki/ESP32-S3-LCD-1.47B) for wiring and additional information.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,104 @@
+#include <Arduino.h>
+#include <TFT_eSPI.h>           // Display library for ST7789
+#include <SPIFFS.h>             // Internal flash storage
+#include <USB.h>                // USB device functionality
+#include <USBHIDKeyboard.h>     // HID keyboard device
+#include <USBHost.h>            // USB host stack for external keyboard
+
+// Simple text editor for ESP32-S3-LCD-1.47B
+
+TFT_eSPI tft = TFT_eSPI();      // Display object
+USBHIDKeyboard hidKeyboard;     // HID keyboard for sending text to phone
+USBHost usbHost;                // USB host controller
+KeyboardController usbKeyboard(usbHost); // External USB keyboard
+
+String currentText;             // In-memory text buffer
+const char *NOTE_PATH = "/note.txt"; // default file location
+
+// HID key codes used by KeyboardController
+#define KEY_F1        0x3A
+#define KEY_F2        0x3B
+#define KEY_F3        0x3C
+#define KEY_BACKSPACE 0x2A
+#define KEY_RETURN    0x28
+
+void drawText() {
+    tft.fillScreen(TFT_BLACK);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setCursor(0, 0);
+    tft.setTextWrap(true, true);
+    tft.print(currentText);
+}
+
+void saveFile(const char *path) {
+    File f = SPIFFS.open(path, FILE_WRITE);
+    if (!f) return;
+    f.print(currentText);
+    f.close();
+}
+
+void openFile(const char *path) {
+    File f = SPIFFS.open(path, FILE_READ);
+    if (!f) return;
+    currentText = f.readString();
+    f.close();
+    drawText();
+}
+
+void sendTextToPhone() {
+    // Send entire text buffer as keystrokes to phone
+    for (size_t i = 0; i < currentText.length(); ++i) {
+        hidKeyboard.write(currentText[i]);
+    }
+}
+
+// Handle input from external USB keyboard
+void onKeyPress(int key) {
+    switch (key) {
+        case KEY_BACKSPACE:
+            if (!currentText.isEmpty()) currentText.remove(currentText.length() - 1);
+            break;
+        case KEY_RETURN:
+            currentText += '\n';
+            break;
+        case KEY_F1:
+            saveFile(NOTE_PATH);
+            break;
+        case KEY_F2:
+            openFile(NOTE_PATH);
+            break;
+        case KEY_F3:
+            sendTextToPhone();
+            break;
+        default:
+            if (key >= 32 && key <= 126) {
+                currentText += (char)key;
+            }
+            break;
+    }
+    drawText();
+}
+
+void setup() {
+    Serial.begin(115200);
+    if (!SPIFFS.begin(true)) {
+        Serial.println("SPIFFS mount failed");
+    }
+    tft.init();
+    tft.setRotation(1);
+    tft.fillScreen(TFT_BLACK);
+
+    usbHost.begin();
+    usbKeyboard.attachPress(onKeyPress); // attach callback
+
+    USB.begin();
+    hidKeyboard.begin();
+
+    drawText();
+}
+
+void loop() {
+    usbHost.Task();         // process USB host events
+    delay(10);
+}
+


### PR DESCRIPTION
## Summary
- refine README with TFT setup notes and arduino-cli instructions
- implement keyboard shortcuts inside callback
- add HID key code constants

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32s3 ./src` *(fails: main file missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877e16c9d6883289e99f785697200a7